### PR TITLE
Update GridView.swift

### DIFF
--- a/SwiftUIGames/SwiftUIComonents/GridView.swift
+++ b/SwiftUIGames/SwiftUIComonents/GridView.swift
@@ -8,6 +8,8 @@
 
 import SwiftUI
 
+typealias Length = CGFloat
+
 /// GridView aligns cells exactly in a grid (without rounding errors).
 /// Any rounding error is left as margin to the side of the grid. Use
 /// `horizontalAlignment` and `verticalAlignment` to


### PR DESCRIPTION
"Length" appears to be deprecated or maybe is defined in a file not included in this repo? 

It is initialized with an Int in GridView.init(), so I tried typealiasing it to Int first.  The compiler complains that it expects a CGFloat in several places though, so I left it as that.